### PR TITLE
CVE-2025-29927 Patch package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "groq-sdk": "^0.9.1",
     "ioredis": "^5.4.1",
     "lucide-react": "^0.468.0",
-    "next": "14.2.23",
+    "next": "14.2.25",
     "next-themes": "^0.4.4",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
CVE-2025-29927 
next.js patched version 14.2.25 (or 15.2.3)