### PR TITLE
fix: remove report moderation token leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:h1-3831804": "node scripts/security-regression-h1-3831804.mjs"
   },
   "dependencies": {
     "@next/third-parties": "^15.1.2",

--- a/scripts/security-regression-h1-3831804.mjs
+++ b/scripts/security-regression-h1-3831804.mjs
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (path) => readFileSync(join(root, path), "utf8");
+
+const reportRoute = read("src/app/api/report/route.ts");
+const blockRoute = read("src/app/api/block/route.ts");
+const blockPage = read("src/app/block/page.tsx");
+const reportButton = read("src/app/components/report-button.tsx");
+
+const checks = [
+  {
+    name: "report route never reads BLOCK_SECRET",
+    pass: !reportRoute.includes("BLOCK_SECRET"),
+  },
+  {
+    name: "report route never returns a ban URL field",
+    pass: !/\bbanUrl\b|\bban_url\b/.test(reportRoute),
+  },
+  {
+    name: "report route does not trust caller supplied rootUrl",
+    pass: !/\brootUrl\b/.test(reportRoute),
+  },
+  {
+    name: "report button no longer sends caller supplied rootUrl",
+    pass: !/\brootUrl\b/.test(reportButton),
+  },
+  {
+    name: "block API no longer exposes a GET handler",
+    pass: !/export\s+async\s+function\s+GET/.test(blockRoute),
+  },
+  {
+    name: "block API requires a header secret instead of a query token",
+    pass: blockRoute.includes('"x-block-secret"') && !/searchParams|get\("token"\)/.test(blockRoute),
+  },
+  {
+    name: "block page no longer calls the destructive API from the browser",
+    pass: !/api\/block|token|searchParams/.test(blockPage),
+  },
+];
+
+const failures = checks.filter((check) => !check.pass);
+
+if (failures.length > 0) {
+  console.error("H1-3831804 regression checks failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure.name}`);
+  }
+  process.exit(1);
+}
+
+console.log(`H1-3831804 regression checks passed (${checks.length} checks).`);

--- a/src/app/api/block/route.ts
+++ b/src/app/api/block/route.ts
@@ -1,16 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { blockIP } from "@/server/storage";
 
-export async function GET(request: NextRequest) {
-    const searchParams = new URL(request.url).searchParams;
-    const ip = searchParams.get("ip");
-    const token = searchParams.get("token");
-
-    if (!ip || !token) {
-        return new NextResponse("Missing ip or token parameter", { status: 400 });
-    }
-
+export async function POST(request: NextRequest) {
     try {
+        const token = request.headers.get("x-block-secret");
+        const { ip } = await request.json() as { ip?: string };
+
+        if (!ip || !token) {
+            return new NextResponse("Missing ip or block secret", { status: 400 });
+        }
+
         await blockIP(ip, token);
         
         return new NextResponse(JSON.stringify({ success: true }), {
@@ -19,6 +18,9 @@ export async function GET(request: NextRequest) {
             },
         });
     } catch (error) {
+        if (error instanceof SyntaxError) {
+            return new NextResponse("Invalid request body", { status: 400 });
+        }
         if (error instanceof Error && error.message === "Invalid token") {
             return new NextResponse("Unauthorized", { status: 401 });
         }

--- a/src/app/api/report/route.ts
+++ b/src/app/api/report/route.ts
@@ -3,8 +3,13 @@ import { getFromStorageWithRegex, getStorageKey } from "@/server/storage";
 import { ROOT_URL } from "@/utils/config";
 
 export async function POST(request: NextRequest) {
-    const { sessionId, version, rootUrl = ROOT_URL, appUrl } = await request.json();
     try {
+        const { sessionId, version, appUrl } = await request.json() as {
+            sessionId: string;
+            version: string;
+            appUrl?: string;
+        };
+
         // Get the app data to find the creator's IP
         const key = getStorageKey(sessionId, version);
         const { value: appDataStr } = await getFromStorageWithRegex(key);
@@ -26,9 +31,6 @@ export async function POST(request: NextRequest) {
             );
         }
 
-        // Generate the ban URL
-        const banUrl = `${rootUrl}/block?ip=${encodeURIComponent(creatorIP)}&token=${encodeURIComponent(process.env.BLOCK_SECRET || "")}`;
-
         // Send to Slack
         const slackWebhookUrl = process.env.SLACK_WEBHOOK;
         if (slackWebhookUrl) {
@@ -37,13 +39,14 @@ export async function POST(request: NextRequest) {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                  ban_url: banUrl,
+                  report_url: `${ROOT_URL}/block`,
+                  creator_ip: creatorIP,
                   app_url: appUrl
                 }),
             });
         }
 
-        return NextResponse.json({ success: true, banUrl });
+        return NextResponse.json({ success: true });
     } catch (error) {
         console.error("Error processing report:", error);
         return NextResponse.json(

--- a/src/app/block/page.tsx
+++ b/src/app/block/page.tsx
@@ -1,59 +1,15 @@
 "use client";
 
-import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { ROOT_URL } from "@/utils/config";
 
-export default function BlockPage({
-  searchParams,
-}: {
-  searchParams: { ip: string; token: string };
-}) {
-  const handleBlock = async () => {
-    try {
-      const response = await fetch(
-        `${ROOT_URL}/api/block?ip=${encodeURIComponent(
-          searchParams.ip
-        )}&token=${encodeURIComponent(searchParams.token)}`,
-        {
-          method: "GET",
-        }
-      );
-
-      if (!response.ok) {
-        throw new Error("Failed to block IP");
-      }
-
-      // Redirect to home page after successful block
-      window.location.href = ROOT_URL;
-    } catch (error) {
-      console.error("Error blocking IP:", error);
-      alert("Failed to block IP. Please try again.");
-    }
-  };
-
+export default function BlockPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-background p-4">
       <Card className="w-full max-w-md p-6 space-y-4">
-        <h1 className="text-2xl font-bold text-center">Confirm Block Action</h1>
+        <h1 className="text-2xl font-bold text-center">Moderation Review</h1>
         <p className="text-center text-muted-foreground">
-          Are you sure you want to block this IP address? This action cannot be
-          undone.
+          Blocking now requires an internal server-side action.
         </p>
-        <div className="flex justify-center space-x-4">
-          <Button
-            variant="destructive"
-            onClick={handleBlock}
-          >
-            Confirm Block
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => window.history.back()}
-          >
-            Cancel
-          </Button>
-        </div>
       </Card>
     </div>
   );

--- a/src/app/components/report-button.tsx
+++ b/src/app/components/report-button.tsx
@@ -23,7 +23,6 @@ export function ReportButton({ sessionId, version }: ReportButtonProps) {
 				body: JSON.stringify({
 					sessionId,
 					appUrl: `${window.location.origin}/apps/${sessionId}/${version}`,
-					rootUrl: window.location.origin,
 					version,
 				}),
 			});


### PR DESCRIPTION
## Summary

- Removes the H1-3831804 `/api/report` leak of a tokenized moderation URL.
- Stops trusting caller-supplied `rootUrl` for moderation/report links.
- Removes browser GET/query-token authorization from `/api/block`.
- Adds a dependency-free regression guard for the confirmed leak path.

## Security Rationale

The old report flow was unauthenticated, loaded the app creator IP, built a `/block?...&token=...` URL with `BLOCK_SECRET`, sent it to Slack, and returned the same URL to the caller. That exposed a privileged moderation token and a destructive block/delete primitive to the reporter.

This patch keeps report submission working but removes the tokenized moderation URL from the response and stops client/browser code from invoking destructive block actions through a URL.

## Internal Context

Checked Slack, Google Drive, and Notion via authenticated fallbacks. No rationale found for preserving caller-controlled `rootUrl`, URL-carried `BLOCK_SECRET`, or unauthenticated access to a destructive moderation link.

Notion MCP OAuth/login was completed on 2026-07-02. Browser workspace search found `CE-421` / `Appgen - add LLM check for user abuse reports to reduce false positives`, a P2 Backlog Cloud Engineering item. That supports historical AppGen abuse-report false-positive concerns, but not the token-in-URL moderation behavior.

Evidence: `evidence/H1-3831804/internal_context.md`

Linear: https://linear.app/groq/issue/SEC-32

## Validation

- `git diff --check`
- `npm run test:h1-3831804`

`pnpm lint` did not run because local dependencies are not installed (`next` not found).

## Follow-Up

Replace the internal `x-block-secret` flow with the product's normal admin-authenticated moderation path when that owner/system is available.
