### PR TITLE
fix: sandbox AppGen shared HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "test:h1-3831774": "node scripts/security-regression-h1-3831774.mjs",
     "lint": "next lint"
   },
   "dependencies": {

--- a/scripts/security-regression-h1-3831774.mjs
+++ b/scripts/security-regression-h1-3831774.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function read(path) {
+	return readFileSync(join(root, path), "utf8");
+}
+
+const helper = read("src/server/sandboxed-html.ts");
+const appRoute = read("src/app/api/apps/[sessionId]/[version]/route.ts");
+const rawRoute = read("src/app/api/apps/[sessionId]/[version]/raw/route.ts");
+const sharedPage = read("src/app/apps/[sessionId]/[version]/page.tsx");
+
+assert.match(
+	helper,
+	/Content-Security-Policy/,
+	"raw HTML responses must include a CSP header",
+);
+assert.match(
+	helper,
+	/sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads/,
+	"raw HTML responses must be CSP sandboxed",
+);
+assert.doesNotMatch(
+	helper,
+	/allow-same-origin/,
+	"raw HTML CSP sandbox must not allow same-origin script execution",
+);
+assert.match(
+	helper,
+	/X-Content-Type-Options/,
+	"raw HTML responses must opt out of content sniffing",
+);
+
+assert.match(
+	appRoute,
+	/renderSandboxedHtml\(data\.html\)/,
+	"?raw=true must use the sandboxed HTML response helper",
+);
+assert.match(
+	rawRoute,
+	/renderSandboxedHtml\(data\.html\)/,
+	"/raw must use the sandboxed HTML response helper",
+);
+assert.doesNotMatch(
+	appRoute,
+	/"Content-Type":\s*"text\/html"/,
+	"?raw=true must not define an unsandboxed direct text/html response",
+);
+assert.doesNotMatch(
+	rawRoute,
+	/"Content-Type":\s*"text\/html"/,
+	"/raw must not define an unsandboxed direct text/html response",
+);
+
+const iframe = sharedPage.match(/<iframe[\s\S]*?srcDoc=\{html\}[\s\S]*?\/>/)?.[0] ?? "";
+assert.match(iframe, /sandbox=/, "shared app iframe must be sandboxed");
+assert.doesNotMatch(
+	iframe,
+	/allow-same-origin/,
+	"shared app iframe sandbox must not allow same-origin script execution",
+);
+
+console.log("H1-3831774 regression checks passed");

--- a/src/app/api/apps/[sessionId]/[version]/raw/route.ts
+++ b/src/app/api/apps/[sessionId]/[version]/raw/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFromStorageWithRegex, getStorageKey } from "@/server/storage";
+import { renderSandboxedHtml } from "@/server/sandboxed-html";
 
 export async function GET(
 	request: NextRequest,
@@ -16,11 +17,7 @@ export async function GET(
 		}
 
 		const data = JSON.parse(value);
-		return new NextResponse(data.html, {
-			headers: {
-				"Content-Type": "text/html",
-			},
-		});
+		return renderSandboxedHtml(data.html);
 	} catch (error) {
 		console.error("Error retrieving raw app:", error);
 		return NextResponse.json(

--- a/src/app/api/apps/[sessionId]/[version]/route.ts
+++ b/src/app/api/apps/[sessionId]/[version]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getFromStorageWithRegex, saveToStorage, getStorageKey, addToGallery, isIPBlocked } from "@/server/storage";
+import { renderSandboxedHtml } from "@/server/sandboxed-html";
 import { verifyHtml } from "@/server/signing";
 
 export async function GET(
@@ -19,11 +20,7 @@ export async function GET(
 
 		const data = JSON.parse(value);
 		if (raw) {
-			return new NextResponse(data.html, {
-				headers: {
-					"Content-Type": "text/html",
-				},
-			});
+			return renderSandboxedHtml(data.html);
 		}
 		return NextResponse.json(data);
 	} catch (error) {

--- a/src/app/apps/[sessionId]/[version]/page.tsx
+++ b/src/app/apps/[sessionId]/[version]/page.tsx
@@ -78,6 +78,8 @@ export default function SharedApp({
 					<iframe
 						title="Shared App"
 						srcDoc={html}
+						sandbox="allow-scripts allow-forms allow-popups allow-modals allow-downloads"
+						referrerPolicy="no-referrer"
 						className="w-full h-full border-0"
 						style={{ height: "100vh" }}
 					/>

--- a/src/server/sandboxed-html.ts
+++ b/src/server/sandboxed-html.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+
+export const SANDBOXED_HTML_CSP =
+	"sandbox allow-scripts allow-forms allow-popups allow-modals allow-downloads";
+
+export function renderSandboxedHtml(html: string) {
+	return new NextResponse(html, {
+		headers: {
+			"Content-Type": "text/html; charset=utf-8",
+			"Content-Security-Policy": SANDBOXED_HTML_CSP,
+			"X-Content-Type-Options": "nosniff",
+			"Referrer-Policy": "no-referrer",
+		},
+	});
+}


### PR DESCRIPTION
## Summary

- Add a shared sandboxed HTML response helper for generated app HTML.
- Use it for both `?raw=true` and `/raw` generated-app responses.
- Sandbox the shared-app `srcDoc` iframe without `allow-same-origin`.
- Add a focused H1 regression script to keep raw responses and iframe rendering sandboxed.

## Security

Broken invariant: stored user-generated HTML could execute in the AppGen origin through raw HTML routes and the shared app iframe.

Enforcement point: raw HTML responses now carry a CSP `sandbox` without `allow-same-origin`, and shared-app iframe execution is sandboxed without `allow-same-origin`.

Covered bypasses: direct `/raw`, `?raw=true`, and shared-page `srcDoc` rendering.

Linear: SEC-36
HackerOne: H1-3831774

## Validation

- `pnpm run test:h1-3831774`
- `pnpm run lint` (passes with pre-existing `prompt-view.tsx` `<img>` warning)
- `pnpm run build` compiles, then fails during page-data collection because local env lacks required Supabase config: `supabaseUrl is required`
